### PR TITLE
Remove redundant command strings that clogs up 1.13's command tooltip

### DIFF
--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPCommand.java
@@ -22,12 +22,6 @@ public class RTPCommand {
 		dispatcher.register(Commands.literal("rtp").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.basic"))
 				.executes(context -> runCommand(context.getSource().getPlayerOrException())
 				));
-		dispatcher.register(Commands.literal("randomtp").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.basic"))
-				.executes(context -> runCommand(context.getSource().getPlayerOrException())
-				));
-		dispatcher.register(Commands.literal("randomteleport").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.basic"))
-				.executes(context -> runCommand( context.getSource().getPlayerOrException())
-				));
 	}
 	
 	private static int runCommand(ServerPlayer p) {

--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPDCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPDCommand.java
@@ -28,20 +28,6 @@ public class RTPDCommand {
 							runCommand(context.getSource().getPlayerOrException(), DimensionArgument.getDimension(context, "dimension"))
 						)
 				));
-		dispatcher.register(Commands.literal("randomteleportdimension").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.interdim"))
-				.then(
-						Commands.argument("dimension", DimensionArgument.dimension())
-						.executes(context ->
-								runCommand(context.getSource().getPlayerOrException(), DimensionArgument.getDimension(context, "dimension"))
-						)
-				));
-		dispatcher.register(Commands.literal("randomtpd").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.interdim"))
-				.then(
-						Commands.argument("dimension", DimensionArgument.dimension())
-						.executes(context ->
-								runCommand(context.getSource().getPlayerOrException(), DimensionArgument.getDimension(context, "dimension"))
-						)
-				));
 	}
 	
 	private static int runCommand(ServerPlayer p, ServerLevel dim) {


### PR DESCRIPTION
I am not experienced with code in the slightest, this might break something.