### PR TITLE
Added flag for disabling biome check completely

### DIFF
--- a/common/src/main/java/com/gmail/picono435/randomtp/api/RandomTPAPI.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/api/RandomTPAPI.java
@@ -56,7 +56,7 @@ public class RandomTPAPI {
             while (!isSafe(world, mutableBlockPos) && (maxTries == -1 || maxTries > 0)) {
                 y++;
                 mutableBlockPos.setY(y);
-                if(y >= 120 || !isInBiomeWhitelist(getBiomeId(getBiomeFromKey(world.getBiome(new BlockPos(x, y, z)).unwrapKey().get())))) {
+                if(y >= 120 || Config.checkBiomes() && !isInBiomeWhitelist(getBiomeId(getBiomeFromKey(world.getBiome(new BlockPos(x, y, z)).unwrapKey().get())))) {
                     x = r.nextInt(highX-lowX) + lowX;
                     y = 50;
                     z = r.nextInt(highZ-lowZ) + lowZ;

--- a/common/src/main/java/com/gmail/picono435/randomtp/config/Config.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/config/Config.java
@@ -28,6 +28,10 @@ public class Config {
         return ConfigHandler.getConfig().node("others").node("use-original").getBoolean();
     }
 
+    public static boolean checkBiomes() {
+        return ConfigHandler.getConfig().node("others").node("check-biomes").getBoolean();
+    }
+
     public static boolean useBiomeWhitelist() {
         return ConfigHandler.getConfig().node("others").node("use-biome-whitelist").getBoolean();
     }

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -27,6 +27,8 @@ others:
   max-tries: -1
   # If you want to use the original RTP system or the /spreadplayers system. [default: true]
   use-original: true
+  # Do you want to check biomes at all (if set to false, the use-biome-whitelist will not be checked, provides more compatibility with mods)? [default: false]
+  check-biomes: false
   # Do you want to use the whitelist or blacklist biomes?  [default: false]
   use-biome-whitelist: false
   # The biome whitelist (Works with namespaces:paths only, use-biome-whitelist:true=whitelist use-biome-whitelist:true=blacklist)


### PR DESCRIPTION
This is used for fixing some bugs that make rtp command unresponsive when some biome mods are added