### PR TITLE
Fix /rtpb using dimensions whitelist instead of biomes whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ The best RandomTP mod ever!
 [![Available For](https://img.shields.io/static/v1?label=Available%20For&style=for-the-badge&color=34aa2f&message=1.18.x-1.12.x)][curseforge:files]
 
 [![Modrinth Downloads](https://img.shields.io/badge/dynamic/json?color=5da545&label=modrinth&query=downloads&url=https://api.modrinth.com/api/v1/mod/randomtp&style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMSAxMSIgd2lkdGg9IjE0LjY2NyIgaGVpZ2h0PSIxNC42NjciICB4bWxuczp2PSJodHRwczovL3ZlY3RhLmlvL25hbm8iPjxkZWZzPjxjbGlwUGF0aCBpZD0iQSI+PHBhdGggZD0iTTAgMGgxMXYxMUgweiIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNBKSI+PHBhdGggZD0iTTEuMzA5IDcuODU3YTQuNjQgNC42NCAwIDAgMS0uNDYxLTEuMDYzSDBDLjU5MSA5LjIwNiAyLjc5NiAxMSA1LjQyMiAxMWMxLjk4MSAwIDMuNzIyLTEuMDIgNC43MTEtMi41NTZoMGwtLjc1LS4zNDVjLS44NTQgMS4yNjEtMi4zMSAyLjA5Mi0zLjk2MSAyLjA5MmE0Ljc4IDQuNzggMCAwIDEtMy4wMDUtMS4wNTVsMS44MDktMS40NzQuOTg0Ljg0NyAxLjkwNS0xLjAwM0w4LjE3NCA1LjgybC0uMzg0LS43ODYtMS4xMTYuNjM1LS41MTYuNjk0LS42MjYuMjM2LS44NzMtLjM4N2gwbC0uMjEzLS45MS4zNTUtLjU2Ljc4Ny0uMzcuODQ1LS45NTktLjcwMi0uNTEtMS44NzQuNzEzLTEuMzYyIDEuNjUxLjY0NSAxLjA5OC0xLjgzMSAxLjQ5MnptOS42MTQtMS40NEE1LjQ0IDUuNDQgMCAwIDAgMTEgNS41QzExIDIuNDY0IDguNTAxIDAgNS40MjIgMCAyLjc5NiAwIC41OTEgMS43OTQgMCA0LjIwNmguODQ4QzEuNDE5IDIuMjQ1IDMuMjUyLjgwOSA1LjQyMi44MDljMi42MjYgMCA0Ljc1OCAyLjEwMiA0Ljc1OCA0LjY5MSAwIC4xOS0uMDEyLjM3Ni0uMDM0LjU2bC43NzcuMzU3aDB6IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM1ZGE0MjYiLz48L2c+PC9zdmc+)][modrinth:files]
-[![Curseforge Downloads](https://img.shields.io/badge/dynamic/json?color=f16436&style=for-the-badge&label=CurseForge&query=downloadCount&url=https://addons-ecs.forgesvc.net/api/v2/addon/354834&logo=CurseForge)][curseforge:files]
+[![CurseForge Downloads](https://img.shields.io/badge/dynamic/json?color=f16436&style=for-the-badge&label=CurseForge&query=downloadCount&url=https://addons-ecs.forgesvc.net/api/v2/addon/354834&logo=CurseForge)][curseforge:files]
 [![GitHub Downloads (all releases)](https://img.shields.io/github/downloads/Picono435/RandomTP/total?style=for-the-badge&amp;label=GitHub&amp;prefix=downloads%20&amp;color=4078c0&amp;logo=github)][releases]
 </div>
 
 
 ## Description
-The best Random Teleport mod ever! With this mod you will be able to random teleport between dimensions and without colliding with mostly anything! Our mod is being updated frequently and is always having issues fixes when reported. Our mod works with both sides! (Client-Side only and Server-Side only). Join our [discord](https://discord.gg/wQj53Hy) for more information about all our mods and plugins!
+The best Random Teleport mod ever! With this mod you will be able to random teleport between dimensions and without colliding with mostly anything! Our mod is being updated frequently and we're always fixing issues when reported. Our mod works with both sides! (Client-Side only and Server-Side only). Join our [Discord](https://discord.gg/wQj53Hy) for more information about all our mods and plugins!
 
 ## Commands
 
@@ -31,13 +31,13 @@ The best Random Teleport mod ever! With this mod you will be able to random tele
 
 ## Versions
 
-This mod is available for Fabric and Forge in these versions: [1.12](https://github.com/Picono435/RandomTP/tree/1.12.2), [1.15 & 1.14](https://github.com/Picono435/RandomTP/tree/1.15.2), [1.16](https://github.com/Picono435/RandomTP/tree/1.16.5) and [1.17](https://github.com/Picono435/RandomTP/tree/1.17.1). Other versions may also work but are not tested, and we do not recommend you to use them.
+This mod is available for Fabric and Forge for these versions: [1.12](https://github.com/Picono435/RandomTP/tree/1.12.2), [1.14 & 1.15](https://github.com/Picono435/RandomTP/tree/1.15.2), [1.16](https://github.com/Picono435/RandomTP/tree/1.16.5) and [1.17](https://github.com/Picono435/RandomTP/tree/1.17.1). Other versions may also work but are not tested, and we do not recommend you use them.
 
 ## Links
 
-My discord server: https://discord.gg/wQj53Hy
+My Discord server: https://discord.gg/wQj53Hy
 
-Curseforge page: https://www.curseforge.com/minecraft/mc-mods/randomtp
+CurseForge page: https://www.curseforge.com/minecraft/mc-mods/randomtp
 
 
 ## License

--- a/common/src/main/java/com/gmail/picono435/randomtp/api/RandomTPAPI.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/api/RandomTPAPI.java
@@ -142,6 +142,22 @@ public class RandomTPAPI {
         throw new AssertionError();
     }
 
+    private static boolean isInBiomeWhitelist(ResourceLocation biome) {
+        //WHITELIST
+        if(Config.useBiomeWhitelist()) {
+            if(biome == null) {
+                return false;
+            }
+            return Config.getAllowedBiomes().contains(biome.toString());
+        //BLACKLIST
+        } else {
+            if(biome == null) {
+                return true;
+            }
+            return !Config.getAllowedBiomes().contains(biome.toString());
+        }
+    }
+
     @ExpectPlatform
     public static boolean hasPermission(CommandSourceStack source, String permission) {
         throw new AssertionError();
@@ -150,7 +166,7 @@ public class RandomTPAPI {
     public static boolean isSafe(ServerLevel world, BlockPos.MutableBlockPos mutableBlockPos) {
         if(mutableBlockPos.getX() >= world.getWorldBorder().getMaxX() || mutableBlockPos.getZ() >= world.getWorldBorder().getMaxZ()) return false;
         if ((isEmpty(world, mutableBlockPos)) &&
-                (!isDangerBlocks(world, mutableBlockPos))) {
+                (!isDangerPos(world, mutableBlockPos))) {
             return true;
         }
         return false;
@@ -165,7 +181,7 @@ public class RandomTPAPI {
         return false;
     }
 
-    public static boolean isDangerBlocks(ServerLevel world, BlockPos.MutableBlockPos mutableBlockPos) {
+    public static boolean isDangerPos(ServerLevel world, BlockPos.MutableBlockPos mutableBlockPos) {
         if(isDangerBlock(world, mutableBlockPos) && isDangerBlock(world, mutableBlockPos.move(0, 1, 0)) &&
                 isDangerBlock(world, mutableBlockPos.move(0, -1, 0))) {
             return true;
@@ -178,22 +194,6 @@ public class RandomTPAPI {
 
     public static boolean isDangerBlock(ServerLevel world, BlockPos.MutableBlockPos mutableBlockPos) {
         return world.getBlockState(mutableBlockPos).getBlock() instanceof LiquidBlock;
-    }
-
-    private static boolean isInBiomeWhitelist(ResourceLocation biome) {
-        //WHITELIST
-        if(Config.useBiomeWhitelist()) {
-            if(biome == null) {
-                return false;
-            }
-            return Config.getAllowedBiomes().contains(biome.toString());
-            //BLACKLIST
-        } else {
-            if(biome == null) {
-                return true;
-            }
-            return !Config.getAllowedBiomes().contains(biome.toString());
-        }
     }
 
     static record ResourceResult<T>(ResourceKey<T> key) implements ResourceOrTagLocationArgument.Result<T> {

--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPBCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPBCommand.java
@@ -57,7 +57,7 @@ public class RTPBCommand {
 				ResourceLocation biomeLocation = biomeKey.location();
 				String biomeId = biomeLocation.getNamespace() + ":" + biomeLocation.getPath();
 				if(!inWhitelist(biomeId)) {
-					p.sendSystemMessage(Component.literal(Messages.getDimensionNotAllowed().replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("\\{biomeId\\}", biomeId.toString()).replace('&', '§')), true);
+					p.sendSystemMessage(Component.literal(Messages.getBiomeNotAllowed().replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("\\{biomeId\\}", biomeId.toString()).replace('&', '§')), true);
 					return 1;
 				}
 				if(Config.useOriginal()) {
@@ -77,13 +77,13 @@ public class RTPBCommand {
 		return 1;
 	}
 	
-	  private static boolean inWhitelist(String dimension) {
+	  private static boolean inWhitelist(String biome) {
 		  //WHITELIST
-		  if(Config.useWhitelist()) {
-			  return Config.getAllowedDimensions().contains(dimension);
+		  if(Config.useBiomeWhitelist()) {
+			  return Config.getAllowedBiomes().contains(biome);
 		  //BLACKLIST
 		  } else {
-			  return !Config.getAllowedDimensions().contains(dimension);
+			  return !Config.getAllowedBiomes().contains(biome);
 		  }
 	  }
 }

--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPCommand.java
@@ -32,8 +32,8 @@ public class RTPCommand {
 		try {
 			if(!RandomTPAPI.checkCooldown(p, cooldowns) && !RandomTPAPI.hasPermission(p, "randomtp.cooldown.exempt")) {
 				long secondsLeft = RandomTPAPI.getCooldownLeft(p, cooldowns);
-				Component cooldownmes = Component.literal(Messages.getCooldown().replaceAll("\\{secondsLeft\\}", Long.toString(secondsLeft)).replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("&", "§"));
-				p.sendSystemMessage(cooldownmes, false);
+				Component cooldownMsg = Component.literal(Messages.getCooldown().replaceAll("\\{secondsLeft\\}", Long.toString(secondsLeft)).replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("&", "§"));
+				p.sendSystemMessage(cooldownMsg, false);
 				return 1;
 			} else {
 				cooldowns.remove(p.getName().getString());

--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPDCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPDCommand.java
@@ -42,8 +42,8 @@ public class RTPDCommand {
 		try {
 			if(!RandomTPAPI.checkCooldown(p, cooldowns) && !RandomTPAPI.hasPermission(p, "randomtp.cooldown.exempt")) {
 				long secondsLeft = RandomTPAPI.getCooldownLeft(p, cooldowns);
-				Component cooldownmes = Component.literal(Messages.getCooldown().replaceAll("\\{secondsLeft\\}", Long.toString(secondsLeft)).replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("&", "§"));
-				p.sendSystemMessage(cooldownmes, false);
+				Component cooldownMsg = Component.literal(Messages.getCooldown().replaceAll("\\{secondsLeft\\}", Long.toString(secondsLeft)).replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("&", "§"));
+				p.sendSystemMessage(cooldownMsg, false);
 				return 1;
 			} else {
 				cooldowns.remove(p.getName().getString());
@@ -87,7 +87,7 @@ public class RTPDCommand {
 	
 	  private static boolean inWhitelist(String dimension) {
 		  //WHITELIST
-		  if(Config.useWhitelist()) {
+		  if(Config.useDimensionWhitelist()) {
 			  return Config.getAllowedDimensions().contains(dimension);
 		  //BLACKLIST
 		  } else {

--- a/common/src/main/java/com/gmail/picono435/randomtp/config/Config.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/config/Config.java
@@ -49,7 +49,7 @@ public class Config {
         return ConfigHandler.getConfig().node("inter-dimensions-command").node("inter-dim").getBoolean();
     }
 
-    public static boolean useWhitelist() {
+    public static boolean useDimensionWhitelist() {
         return ConfigHandler.getConfig().node("inter-dimensions-command").node("use-whitelist").getBoolean();
     }
 

--- a/common/src/main/java/com/gmail/picono435/randomtp/config/Messages.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/config/Messages.java
@@ -2,7 +2,7 @@ package com.gmail.picono435.randomtp.config;
 
 public class Messages {
     public static String getMaxTries() {
-        return ConfigHandler.getConfig().node("command").node("max-tries").getString();
+        return ConfigHandler.getMessages().node("command").node("max-tries").getString();
     }
 
     public static String getFinding() {

--- a/common/src/main/java/com/gmail/picono435/randomtp/config/Messages.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/config/Messages.java
@@ -1,6 +1,9 @@
 package com.gmail.picono435.randomtp.config;
 
 public class Messages {
+    public static String getMaxTries() {
+        return ConfigHandler.getConfig().node("command").node("max-tries").getString();
+    }
 
     public static String getFinding() {
         return ConfigHandler.getMessages().node("command").node("finding").getString();
@@ -21,9 +24,4 @@ public class Messages {
     public static String getBiomeNotAllowed() {
         return ConfigHandler.getMessages().node("command").node("biomeNotAllowed").getString();
     }
-
-    public static String getMaxTries() {
-        return ConfigHandler.getConfig().node("command").node("max-tries").getString();
-    }
-
 }

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -1,39 +1,71 @@
 distance:
-  # The default world that you are teleported when doing /rtp (Only supported when use-original is set to true) [playerworld: the world on where the player is, default: playerworld]
+  # The default world you are teleported to when using /rtp.
+  # (only supported when use-original is set to true)
+  # (playerworld: the world you're is currently in)
+  # [default: playerworld]
   default_world: playerworld
-  # Max distance that you want to a person be teleported. (0 = world border size / 2) [default: auto]
+  # Maximum distance you want you to be teleported.
+  # (0 = world border size / 2)
+  # (otherwise, must be more than 0)
+  # [default: auto]
   # Range: > 0
-  max_distance: 10000
-  # Minimum distance that you want to a person be teleported. [default: 1]
-  # Range: > 1
+  max_distance: 0
+  # Minimum distance you want you to be teleported.
+  # (must be more than 0)
+  # [default: 1]
   min_distance: 1
 
 inter-dimensions-command:
-  # Do you want to the command /rtpd be allowed? (This commands adds a inter-dimension RTP) [default: true]
+  # Do you want to enable the /rtpd command?
+  # This commands allows you to teleport to a random location in a specified dimension.
+  # [default: true]
   inter-dim: true
-  # Do you want to use the whitelist or blacklist dimension?  [default: false]
+  # Do you want to whitelist or blacklist destination dimensions?
+  # [default: false]
   use-whitelist: false
-  # The dimensions whitelist (Works with namespaces:paths only, use-whitelist:true=whitelist use-whitelist:true=blacklist)
+  # The dimension whitelist / blacklist.
+  # (works with namespaces:paths only)
+  # [default: minecraft:the_end (The End - vanilla) and twilight:dimension (The Twilight Forest - mod]
   whitelist-dimension:
     - 'minecraft:the_end'
     - 'twilight:dimension'
 
 inter-biomes-command:
-  # Do you want to the command /rtpb be allowed? (This commands adds a inter-biome RTP) [default: true]
+  # Do you want to enable the /rtpb command?
+  # This commands allows you to teleport to a random location in a specified biome.
+  # [default: true]
   inter-biome: true
 
 others:
-  # The amount of tries to find a safe location (original system) [-1: infinite, default: -1]
+  # How many times should the mod look for a safe teleport destination?
+  # (only supported when use-original is set to true)
+  # [-1: infinite, default: -1]
   max-tries: -1
-  # If you want to use the original RTP system or the /spreadplayers system. [default: true]
+  # What RTP system should the mod use?
+  # true = the mod's custom RTP system
+  # false = the vanilla /spreadplayers system
+  # [default: true]
   use-original: true
-  # Do you want to use the whitelist or blacklist biomes?  [default: false]
+  # Do you want to whitelist or blacklist destination biomes?
+  # true = whitelist
+  # false = blacklist
+  # [default: false]
   use-biome-whitelist: false
-  # The biome whitelist (Works with namespaces:paths only, use-biome-whitelist:true=whitelist use-biome-whitelist:true=blacklist)
+  # The biome whitelist / blacklist.
+  # (uses namespace:path format)
+  # [default: all vanilla oceans]
   biome-whitelist:
+    - 'minecraft:warm_ocean'
+    - 'minecraft:lukewarm_ocean'
+    - 'minecraft:deep_lukewarm_ocean'
     - 'minecraft:ocean'
     - 'minecraft:deep_ocean'
+    - 'minecraft:cold_ocean'
+    - 'minecraft:deep_cold_ocean'
+    - 'minecraft:frozen_ocean'
+    - 'minecraft:deep_frozen_ocean'
 
-  # How much cooldown do you want for the command [range: 0 ~ 1000, default: 0]
-  # Range: > 0
+  # How long do you want the command cooldown to be?
+  # (range: 0 ~ 1000)
+  # [default: 0]
   cooldown: 0

--- a/common/src/main/resources/messages.yml
+++ b/common/src/main/resources/messages.yml
@@ -1,16 +1,27 @@
+# All messages accept color codes using "& + (letter)".
+# For example, "&c" makes all following text red.
 command:
-  # Message that you want to appear when the max tries of finding a safe location is reached [ placeholders: {playerName}, color codes: & + letter (example: &c) ].
-  max-tries: '&cTimed out trying to find a safe location to warp to.'
-  # Message that you want to appear when the mod is finding a safe location [ placeholders: {playerName} {blockZ} {blockY}, color codes: & + letter (example: &c) ] [default: &aFinding a safe random teleport location...]
-  finding: >-
-    &aFinding a safe random teleport location...
-  # Message that you want to appear when the command is successfully made. [ placeholders: {playerName} {blockZ} {blockY}, color codes: & + letter (example: &c) ] [default: &aSuccessfully teleported you to a random location.]
-  successfully: >-
-    &aYou have been teleported to the coordinates &e{blockX}, {blockY},
-    {blockZ}&a.
-  # Message that you want to appear when the command is on cooldown. [ placeholders: {playerName}, color codes: & + letter (example: &c) ] [default: &cWait more {secondsLeft} seconds for execute the command again.]
-  cooldown: '&cWait more {secondsLeft} seconds for execute the command again.'
-  # Message that you want to appear when you execute /rtpd with a dimension that is in the blacklist [ placeholders: {playerName} {dimensionId}, color codes: & + letter (example: &c) ]. [default: &cYou cannot random teleport to that dimension!]
-  dimensionNotAllowed: '&cYou cannot random teleport to that dimension!'
-  # Message that you want to appear when you execute /rtpd with a dimension that is in the blacklist [ placeholders: {playerName} {dimensionId}, color codes: & + letter (example: &c) ]. [default: &cYou cannot random teleport to that dimension!]
-  biomeNotAllowed: '&cYou cannot random teleport to that biome!'
+  # Message that appears when the max tries of finding a safe destination is reached.
+  # (placeholders: {playerName})
+  # [default: '&cTimed out trying to find a safe location to teleport to.']
+  max-tries: '&cTimed out trying to find a safe location to teleport to.'
+  # Message that appears while the mod is finding a safe location.
+  # (placeholders: {playerName} {blockX} {blockY} {blockZ})
+  # [default: '&aFinding a safe random teleport location...']
+  finding: '&aFinding a safe teleport location...'
+  # Message that appears when the teleport is successful.
+  # (placeholders: {playerName} {blockX} {blockY} {blockZ})
+  # [default: '&aSuccessfully teleported you to a random location.']
+  successfully: '&aSuccessfully teleported you to a random location.'
+  # Message that appears when the command is on cooldown.
+  # (placeholders: {playerName} ${secondsLeft})
+  # [default: '&cWait {secondsLeft} more seconds to execute that command again.']
+  cooldown: '&cWait {secondsLeft} more seconds to execute that command again.'
+  # Message that appears when a player tries to teleport to a blacklisted dimension.
+  # (placeholders: {playerName} {dimensionId},)
+  # [default: '&cYou cannot random teleport to that dimension!']
+  dimensionNotAllowed: '&cYou cannot teleport to that dimension!'
+  # Message that appears when a player tries to teleport to a biome that blacklisted.
+  # (placeholders: {playerName} {biomeId})
+  # [default: '&cYou cannot random teleport to that biome!']
+  biomeNotAllowed: '&cYou cannot teleport to that biome!'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=false
 minecraft_version=1.19.2
 
 archives_base_name=randomtp
-mod_version=7.1.0+1.19
+mod_version=7.1.1+1.19
 maven_group=com.gmail.picono435
 
 fabric_loader_version=0.14.9


### PR DESCRIPTION
As it stands, `/rtpb` uses the dimensions whitelist is instead of the biomes whitelist to check for valid biomes.
https://github.com/Picono435/RandomTP/blob/1.19/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPBCommand.java#L80
So, when executing `/rtpb`, the player will always see the "You cannot random teleport to that dimension!" message, and won't be teleported.

This pull request fixes that, as well as prettifies the config files and fixes some grammar issues.

(also I fixed #11)