### PR TITLE
Make commands public to use them in other mods

### DIFF
--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPBCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPBCommand.java
@@ -1,6 +1,5 @@
 package com.gmail.picono435.randomtp.commands;
 
-import com.gmail.picono435.randomtp.api.RandomTPAPI;
 import com.gmail.picono435.randomtp.config.Config;
 import com.gmail.picono435.randomtp.config.Messages;
 import com.mojang.brigadier.CommandDispatcher;
@@ -18,19 +17,21 @@ import net.minecraft.world.level.biome.Biome;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.gmail.picono435.randomtp.api.RandomTPAPI.*;
+
 public class RTPBCommand {
 
-	private static Map<String, Long> cooldowns = new HashMap<String, Long>();
+	private static final Map<String, Long> cooldowns = new HashMap<String, Long>();
 
 	public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext commandBuildContext) {
-		dispatcher.register(Commands.literal("rtpb").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.interbiome"))
+		dispatcher.register(Commands.literal("rtpb").requires(source -> hasPermission(source, "randomtp.command.interbiome"))
 				.then(
 						Commands.argument("biome", ResourceOrTagArgument.resourceOrTag(commandBuildContext, Registries.BIOME))
 								.executes(context ->
 										runCommand(context.getSource().getPlayerOrException(), ResourceOrTagArgument.getResourceOrTag(context, "biome", Registries.BIOME))
 								)
 				));
-		dispatcher.register(Commands.literal("biomertp").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.interbiome"))
+		dispatcher.register(Commands.literal("biomertp").requires(source -> hasPermission(source, "randomtp.command.interbiome"))
 				.then(
 						Commands.argument("biome", ResourceOrTagArgument.resourceOrTag(commandBuildContext, Registries.BIOME))
 								.executes(context ->
@@ -39,10 +40,10 @@ public class RTPBCommand {
 				));
 	}
 	
-	private static int runCommand(ServerPlayer p, ResourceOrTagArgument.Result<Biome> biome) {
+	public static int runCommand(ServerPlayer p, ResourceOrTagArgument.Result<Biome> biome) {
 		try {
-			if(!RandomTPAPI.checkCooldown(p, cooldowns) && !RandomTPAPI.hasPermission(p, "randomtp.cooldown.exempt")) {
-				long secondsLeft = RandomTPAPI.getCooldownLeft(p, cooldowns);
+			if(!checkCooldown(p, cooldowns) && !hasPermission(p, "randomtp.cooldown.exempt")) {
+				long secondsLeft = getCooldownLeft(p, cooldowns);
 				Component cooldownmes = Component.literal(Messages.getCooldown().replaceAll("\\{secondsLeft\\}", Long.toString(secondsLeft)).replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("&", "§"));
 				p.sendSystemMessage(cooldownmes, false);
 				return 1;
@@ -57,7 +58,7 @@ public class RTPBCommand {
 				if(Config.useOriginal()) {
 					Component finding = Component.literal(Messages.getFinding().replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("\\{blockX\\}", "" + (int)p.position().x).replaceAll("\\{blockY\\}", "" + (int)p.position().y).replaceAll("\\{blockZ\\}", "" + (int)p.position().z).replaceAll("&", "§"));
 					p.sendSystemMessage(finding, false);
-					RandomTPAPI.randomTeleport(p, p.serverLevel(), biomeKey);
+					randomTeleport(p, p.serverLevel(), biomeKey);
 					cooldowns.put(p.getName().getString(), System.currentTimeMillis());
 					return 1;
 				}

--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPCommand.java
@@ -1,36 +1,36 @@
 package com.gmail.picono435.randomtp.commands;
 
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.gmail.picono435.randomtp.api.RandomTPAPI;
 import com.gmail.picono435.randomtp.config.Config;
 import com.gmail.picono435.randomtp.config.Messages;
 import com.mojang.brigadier.CommandDispatcher;
-
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.gmail.picono435.randomtp.api.RandomTPAPI.*;
+
 public class RTPCommand {
 	
-	private static Map<String, Long> cooldowns = new HashMap<String, Long>();
+	private static final Map<String, Long> cooldowns = new HashMap<String, Long>();
 	
 	public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-		dispatcher.register(Commands.literal("rtp").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.basic"))
+		dispatcher.register(Commands.literal("rtp").requires(source -> hasPermission(source, "randomtp.command.basic"))
 				.executes(context -> runCommand(context.getSource().getPlayerOrException())
 				));
-		dispatcher.register(Commands.literal("randomtp").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.basic"))
+		dispatcher.register(Commands.literal("randomtp").requires(source -> hasPermission(source, "randomtp.command.basic"))
 				.executes(context -> runCommand(context.getSource().getPlayerOrException())
 				));
 	}
 	
-	private static int runCommand(ServerPlayer p) {
+	public static int runCommand(ServerPlayer p) {
 		try {
-			if(!RandomTPAPI.checkCooldown(p, cooldowns) && !RandomTPAPI.hasPermission(p, "randomtp.cooldown.exempt")) {
-				long secondsLeft = RandomTPAPI.getCooldownLeft(p, cooldowns);
+			if(!checkCooldown(p, cooldowns) && !hasPermission(p, "randomtp.cooldown.exempt")) {
+				long secondsLeft = getCooldownLeft(p, cooldowns);
 				Component cooldownmes = Component.literal(Messages.getCooldown().replaceAll("\\{secondsLeft\\}", Long.toString(secondsLeft)).replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("&", "§"));
 				p.sendSystemMessage(cooldownmes, false);
 				return 1;
@@ -40,9 +40,9 @@ public class RTPCommand {
 					Component finding = Component.literal(Messages.getFinding().replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("\\{blockX\\}", "" + (int)p.position().x).replaceAll("\\{blockY\\}", "" + (int)p.position().y).replaceAll("\\{blockZ\\}", "" + (int)p.position().z).replaceAll("&", "§"));
 					p.sendSystemMessage(finding, false);
 					if(!Config.getDefaultWorld().equals("playerworld")) {
-						RandomTPAPI.randomTeleport(p, RandomTPAPI.getWorld(Config.getDefaultWorld(), p.getServer()));
+						randomTeleport(p, getWorld(Config.getDefaultWorld(), p.getServer()));
 					} else {
-						RandomTPAPI.randomTeleport(p, p.serverLevel());
+						randomTeleport(p, p.serverLevel());
 					}
 					cooldowns.put(p.getName().getString(), System.currentTimeMillis());
 					return 1;

--- a/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPDCommand.java
+++ b/common/src/main/java/com/gmail/picono435/randomtp/commands/RTPDCommand.java
@@ -1,14 +1,8 @@
 package com.gmail.picono435.randomtp.commands;
 
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.gmail.picono435.randomtp.api.RandomTPAPI;
 import com.gmail.picono435.randomtp.config.Config;
 import com.gmail.picono435.randomtp.config.Messages;
 import com.mojang.brigadier.CommandDispatcher;
-
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.DimensionArgument;
@@ -16,19 +10,25 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.gmail.picono435.randomtp.api.RandomTPAPI.*;
+
 public class RTPDCommand {
 	
-	private static Map<String, Long> cooldowns = new HashMap<String, Long>();
+	private static final Map<String, Long> cooldowns = new HashMap<String, Long>();
 
 	public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-		dispatcher.register(Commands.literal("rtpd").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.interdim"))
+		dispatcher.register(Commands.literal("rtpd").requires(source -> hasPermission(source, "randomtp.command.interdim"))
 				.then(
 						Commands.argument("dimension", DimensionArgument.dimension())
 						.executes(context -> 
 							runCommand(context.getSource().getPlayerOrException(), DimensionArgument.getDimension(context, "dimension"))
 						)
 				));
-		dispatcher.register(Commands.literal("dimensionrtp").requires(source -> RandomTPAPI.hasPermission(source, "randomtp.command.interdim"))
+		dispatcher.register(Commands.literal("dimensionrtp").requires(source -> hasPermission(source, "randomtp.command.interdim"))
 				.then(
 						Commands.argument("dimension", DimensionArgument.dimension())
 								.executes(context ->
@@ -37,10 +37,10 @@ public class RTPDCommand {
 				));
 	}
 	
-	private static int runCommand(ServerPlayer p, ServerLevel dim) {
+	public static int runCommand(ServerPlayer p, ServerLevel dim) {
 		try {
-			if(!RandomTPAPI.checkCooldown(p, cooldowns) && !RandomTPAPI.hasPermission(p, "randomtp.cooldown.exempt")) {
-				long secondsLeft = RandomTPAPI.getCooldownLeft(p, cooldowns);
+			if(!checkCooldown(p, cooldowns) && !hasPermission(p, "randomtp.cooldown.exempt")) {
+				long secondsLeft = getCooldownLeft(p, cooldowns);
 				Component cooldownmes = Component.literal(Messages.getCooldown().replaceAll("\\{secondsLeft\\}", Long.toString(secondsLeft)).replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("&", "§"));
 				p.sendSystemMessage(cooldownmes, false);
 				return 1;
@@ -48,13 +48,13 @@ public class RTPDCommand {
 				cooldowns.remove(p.getName().getString());
 				String dimensionId = dim.dimension().location().getNamespace() + ":" + dim.dimension().location().getPath();
 				if(!inWhitelist(dimensionId)) {
-					p.sendSystemMessage(Component.literal(Messages.getDimensionNotAllowed().replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("\\{dimensionId\\}", dimensionId.toString()).replace('&', '§')), false);
+					p.sendSystemMessage(Component.literal(Messages.getDimensionNotAllowed().replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("\\{dimensionId\\}", dimensionId).replace('&', '§')), false);
 					return 1;
 				}
 				if(Config.useOriginal()) {
 					Component finding = Component.literal(Messages.getFinding().replaceAll("\\{playerName\\}", p.getName().getString()).replaceAll("\\{blockX\\}", "" + (int)p.position().x).replaceAll("\\{blockY\\}", "" + (int)p.position().y).replaceAll("\\{blockZ\\}", "" + (int)p.position().z).replaceAll("&", "§"));
 					p.sendSystemMessage(finding, false);
-					RandomTPAPI.randomTeleport(p, dim);
+					randomTeleport(p, dim);
 					cooldowns.put(p.getName().getString(), System.currentTimeMillis());
 					return 1;
 				}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=false
 enabled_platforms=fabric,neoforge,forge
 
 archives_name=randomtp
-mod_version=8.1.0
+mod_version=8.2.0
 maven_group=com.gmail.picono435
 
 minecraft_version=1.20.6


### PR DESCRIPTION
With these changes, we can write this kind of code in custom mods:

```
 ResourceLocation resourceLocation = ResourceLocation.read("my:world").getOrThrow();
 ResourceKey<Level> resourceKey = ResourceKey.create(Registries.DIMENSION, resourceLocation);
 RTPDCommand.runCommand(player, server.getLevel(resourceKey));
```

Which allow modders to forbid the use of rtp commands directly by the player but enable it through custom mod conditions